### PR TITLE
Fix anchors links and github page refresh

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -17,6 +17,37 @@
   </head>
   <body>
     {{content-for "body"}}
+    <!-- Start Single Page Apps for GitHub Pages -->
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafrex/spa-github-pages
+      // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+      // ----------------------------------------------------------------------
+      // This script checks to see if a redirect is present in the query string
+      // and converts it back into the correct url and adds it to the
+      // browser's history using window.history.replaceState(...),
+      // which won't cause the browser to attempt to load the new url.
+      // When the single page app is loaded further down in this file,
+      // the correct url will be waiting in the browser's history for
+      // the single page app to route accordingly.
+      (function(l) {
+        if (l.search) {
+          var q = {};
+          l.search.slice(1).split('&').forEach(function(v) {
+            var a = v.split('=');
+            q[a[0]] = a.slice(1).join('=').replace(/~and~/g, '&');
+          });
+          if (q.p !== undefined) {
+            window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + (q.p || '') +
+              (q.q ? ('?' + q.q) : '') +
+              l.hash
+            );
+          }
+        }
+      }(window.location))
+    </script>
+    <!-- End Single Page Apps for GitHub Pages -->
 
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/a11y-demo-app.js"></script>

--- a/app/router.js
+++ b/app/router.js
@@ -18,4 +18,5 @@ Router.map(function() {
   this.route('addons', function() {
     this.route('ember-moment');
   });
+  this.route('not-found', { path: '*path' })
 });

--- a/app/router.js
+++ b/app/router.js
@@ -18,5 +18,4 @@ Router.map(function() {
   this.route('addons', function() {
     this.route('ember-moment');
   });
-  
 });

--- a/app/templates/not-found.hbs
+++ b/app/templates/not-found.hbs
@@ -1,0 +1,2 @@
+<h1>Not found</h1>
+<p>This page doesn't exist. <LinkTo @route="index">Head home?</LinkTo></p>

--- a/config/environment.js
+++ b/config/environment.js
@@ -44,9 +44,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.locationType = 'hash';
     ENV.rootURL = '/a11y-demo-app/';
-
   }
 
   return ENV;

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const Funnel = require('broccoli-funnel');
 
 module.exports = function(defaults) {
   let app = new EmberApp(defaults, {
@@ -21,6 +22,8 @@ module.exports = function(defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
-
-  return app.toTree();
+  let notFoundPage = new Funnel('./vendor', {
+    include: ['404.html']
+  })
+  return app.toTree(notFoundPage);
 };

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@glimmer/tracking": "^1.0.0",
     "babel-eslint": "^10.0.3",
     "broccoli-asset-rev": "^3.0.0",
+    "broccoli-funnel": "^3.0.3",
     "ember-auto-import": "^1.5.3",
     "ember-cli": "~3.16.1",
     "ember-cli-app-version": "^3.2.0",

--- a/vendor/404.html
+++ b/vendor/404.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Redirect</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // https://github.com/rafrex/spa-github-pages
+      // Copyright (c) 2016 Rafael Pedicini, licensed under the MIT License
+      // ----------------------------------------------------------------------
+      // This script takes the current url and converts the path and query
+      // string into just a query string, and then redirects the browser
+      // to the new url with only a query string and hash fragment,
+      // e.g. http://www.foo.tld/one/two?a=b&c=d#qwe, becomes
+      // http://www.foo.tld/?p=/one/two&q=a=b~and~c=d#qwe
+      // Note: this 404.html file must be at least 512 bytes for it to work
+      // with Internet Explorer (it is currently > 512 bytes)
+      // If you're creating a Project Pages site and NOT using a custom domain,
+      // then set segmentCount to 1 (enterprise users may need to set it to > 1).
+      // This way the code will only replace the route part of the path, and not
+      // the real directory in which the app resides, for example:
+      // https://username.github.io/repo-name/one/two?a=b&c=d#qwe becomes
+      // https://username.github.io/repo-name/?p=/one/two&q=a=b~and~c=d#qwe
+      // Otherwise, leave segmentCount as 0.
+      var segmentCount = 1;
+      var l = window.location;
+      var segments = l.pathname.split('/');
+
+      // Avoid an infinite loop if we try to direct to a location that doesn't exist
+      if (!/^\?p=\/.*&q=.*/.test(l.search)) {
+        l.replace(
+          l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+          segments.slice(0, 1 + segmentCount).join('/') + '/?p=/' +
+          segments.slice(segmentCount+1).join('/').replace(/&/g, '~and~') +
+          (l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+          l.hash
+        );
+      }
+    </script>
+  </head>
+  <body>The requested page wasn't found.</body>
+</html>


### PR DESCRIPTION
This is a fix for #30.
I've removed the settings `locationType` `hash` for productions build. Now links are generated without a `#` inside and make it possible to use to anchors links in pages.

Changing the settings `locationType` breaks the page refresh on github, to fix this problem I've used the same solution as [ember-cli-addon-docs](https://github.com/ember-learn/ember-cli-addon-docs/). I've created a [`404.html` page](https://github.com/ember-a11y/a11y-demo-app/pull/31/files#diff-e213ad74dd5c0e4406e4277d5760ae53) this page is displayed by GitHub when you try to access a page that doesn't exist. This page contains the script provided by this project [spa-github-pages](https://github.com/rafrex/spa-github-pages) which takes the currentUrl, move the part causing the 404 into a query param and redirect to the github index page. In the [index.html]() page there's another script that will take the URL and move back the parts that are in the query params into the URL location.

Basically this what happen :

1. Someone try access https://ember-a11y.github.io/a11y-demo-app/foo
2. The page does not exist so github render the 404.html page
3. The script in the page transform the URL into https://ember-a11y.github.io/a11y-demo-app?q=/foo
4. User is redirected to https://ember-a11y.github.io/a11y-demo-app
5. The script in the index.html will transform the URL from https://ember-a11y.github.io/a11y-demo-app?q=/foo into https://ember-a11y.github.io/a11y-demo-app/foo using `window.history.replaceState`
6. Because the script in index.html use `window.history.replaceState` ember router will redirect to correct page
