### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ember-cli-github-pages": "0.0.8",
     "ember-cli-htmlbars": "^4.2.2",
     "ember-cli-inject-live-reload": "^2.0.2",
-    "ember-cli-moment-shim": "~3.7.1",
+    "ember-cli-moment-shim": "^3.8.0",
     "ember-cli-sass": "^10.0.1",
     "ember-cli-sri": "^2.1.1",
     "ember-cli-template-lint": "^1.0.0-beta.3",


### PR DESCRIPTION
I've dug into the build and found that it was failing because of momentjs. I don't really know why but a `}` was missing somewhere causing uglify to fail. I've updated `ember-cli-moment-shim` and now the build is working again (at least in local).